### PR TITLE
Don't define different classes for each character

### DIFF
--- a/regexfactory/chars.py
+++ b/regexfactory/chars.py
@@ -1,48 +1,11 @@
-r"""Module for regex characters like `\w` or `\D` or `.`"""
+r"""Module for common regex characters, such as `\d`, `.`, ..."""
 
-from .pattern import RegexPattern, escape
+from .patterns import RegexPattern
 
-
-class RegexChar(RegexPattern):
-    regex: str = ''
-
-    def __init__(self, character: str = None):
-        if character:
-            self.regex = escape(character)
-
-
-class Whitespace(RegexChar):
-    regex = r'\s'
-
-
-class NotWhitespace(RegexChar):
-    regex = r'\S'
-
-
-class Any(RegexChar):
-    regex = r'.'
-
-
-class Word(RegexChar):
-    regex = r'\w'
-
-
-class NotWord(RegexChar):
-    regex = r'\W'
-
-
-class Digit(RegexChar):
-    regex = r'\d'
-
-
-class NotDigit(RegexChar):
-    regex = r'\D'
-
-
-ANY = Any()
-WHITESPACE = Whitespace()
-NOTWHITESPACE = NotWhitespace()
-WORD = Word()
-NOTWORD = NotWord()
-DIGIT = Digit()
-NOTDIGIT = NotDigit()
+ANY = RegexPattern(r".")
+WHITESPACE = RegexPattern(r"\s")
+NOTWHITESPACE = RegexPattern(r"\S")
+WORD = RegexPattern(r"\w")
+NOTWORD = RegexPattern(r"\W")
+DIGIT = RegexPattern(r"\d")
+NOTDIGIT = RegexPattern(r"\D")


### PR DESCRIPTION
Currently, in the `chars.py`, you define custom classes for each special character. This is very weird behavior as it defies the purpose of classes in the first place. Each class should be a template and it is expected to be instantiated multiple times making different objects based on that blueprint. Making class singletons like these should generally be discouraged.

I've also removed the `RegexChar` class as a whole, since it was basically doing the same thing as `RegexPattern` except it was only supposed to contain one character (which wasn't actually enforced by the class).