### PR TITLE
Use proper typing

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ pattern = Optional("#") + Or(
         ),
         6
     ),
-    
+
 )
 
 sentence = """
@@ -76,10 +76,10 @@ from regexfactory import *
 import re
 
 
-protocol = Amount(Range("a", "z"), 1, ormore=True)
-host = Amount(Set(WORD, DIGIT, '.'), 1, ormore=True)
-port = Optional(Group(RegexPattern(":") + Amount(DIGIT, 1, ormore=True)))
-path = Amount(Group(RegexPattern('/') + Group(Amount(NotSet('/', '#', '?', '&', WHITESPACE), 0, ormore=True))), 0, ormore=True)
+protocol = Amount(Range("a", "z"), 1, or_more=True)
+host = Amount(Set(WORD, DIGIT, '.'), 1, or_more=True)
+port = Optional(Group(RegexPattern(":") + Amount(DIGIT, 1, or_more=True)))
+path = Amount(Group(RegexPattern('/') + Group(Amount(NotSet('/', '#', '?', '&', WHITESPACE), 0, or_more=True))), 0, or_more=True)
 patt = protocol + RegexPattern("://") + host + port + path
 
 

--- a/examples/urls.py
+++ b/examples/urls.py
@@ -12,11 +12,10 @@ from regexfactory import (
 )
 import re
 
-
-protocol = Amount(Range("a", "z"), 1, ormore=True)
-host = Amount(Set(WORD, DIGIT, '.'), 1, ormore=True)
-port = Optional(Group(RegexPattern(":") + Amount(DIGIT, 1, ormore=True)))
-path = Amount(Group(RegexPattern('/') + Group(Amount(NotSet('/', '#', '?', '&', WHITESPACE), 0, ormore=True))), 0, ormore=True)
+protocol = Amount(Range("a", "z"), 1, or_more=True)
+host = Amount(Set(WORD, DIGIT, '.'), 1, or_more=True)
+port = Optional(Group(RegexPattern(":") + Amount(DIGIT, 1, or_more=True)))
+path = Amount(Group(RegexPattern('/') + Group(Amount(NotSet('/', '#', '?', '&', WHITESPACE), 0, or_more=True))), 0, or_more=True)
 patt = protocol + RegexPattern("://") + host + port + path
 
 

--- a/regexfactory/pattern.py
+++ b/regexfactory/pattern.py
@@ -1,6 +1,9 @@
 """Module for the RegexPattern class"""
 
+from re import Pattern
+from typing import Union
 
+ValidPatternType = Union[Pattern, str, "RegexPattern"]
 escaped_characters = {
     "*",
     ".",
@@ -13,14 +16,14 @@ escaped_characters = {
 }
 
 
-def join(*patterns):
+def join(*patterns: ValidPatternType) -> str:
     joined = ''
     for pattern in patterns:
         joined += str(pattern)
     return joined
 
 
-def escape(character: str):
+def escape(character: str) -> str:
     if character in escaped_characters:
         character = "\\" + character
     return character
@@ -29,16 +32,27 @@ def escape(character: str):
 class RegexPattern:
     regex: str
 
-    def __init__(self, pattern):
-        if isinstance(pattern, RegexPattern):
-            pattern = pattern.regex
-        self.regex = pattern
+    def __init__(self, pattern: ValidPatternType):
+        self.regex = self.get_regex(pattern)
+
+    @staticmethod
+    def get_regex(obj: ValidPatternType) -> str:
+        if isinstance(obj, RegexPattern):
+            return obj.regex
+        elif isinstance(obj, str):
+            return obj
+        elif isinstance(obj, Pattern):
+            return obj.pattern
+
+        raise TypeError(f"Can't get regex from {obj.__class__.__qualname__} object.")
 
     def __str__(self):
         return self.regex
 
-    def __add__(self, other):
-        if isinstance(other, RegexPattern):
-            other = other.regex
+    def __add__(self, other: ValidPatternType) -> "RegexPattern":
+        try:
+            other = self.get_regex(other)
+        except TypeError:
+            return NotImplemented
 
         return RegexPattern(self.regex + other)

--- a/regexfactory/patterns.py
+++ b/regexfactory/patterns.py
@@ -26,7 +26,7 @@ class Range(RegexPattern):
 
 
 class Set(RegexPattern):
-    def __init__(self, *patterns: Union[str, Range]):
+    def __init__(self, *patterns: ValidPatternType):
         regex = ''
         for p in patterns:
             if isinstance(p, Range):
@@ -37,7 +37,7 @@ class Set(RegexPattern):
 
 
 class NotSet(RegexPattern):
-    def __init__(self, *patterns: Union[str, Range]):
+    def __init__(self, *patterns: ValidPatternType):
         regex = ''
         for p in patterns:
             if isinstance(p, Range):

--- a/regexfactory/patterns.py
+++ b/regexfactory/patterns.py
@@ -1,7 +1,7 @@
 """Module for Regex pattern classes like `[^abc]` or (abc) a|b"""
 
 from .pattern import RegexPattern, ValidPatternType
-from typing import Union, overload
+from typing import Tuple, Optional, overload
 import inspect
 
 
@@ -70,7 +70,7 @@ class Amount(RegexPattern):
         super().__init__(regex)
 
     @staticmethod
-    def parse_init_args(*args, **kwargs):
+    def parse_init_args(*args, **kwargs) -> Tuple[int, Optional[int], bool]:
         s1 = inspect.Signature(
             parameters=(
                 inspect.Parameter("repetitions", kind=inspect.Parameter.POSITIONAL_OR_KEYWORD),

--- a/regexfactory/patterns.py
+++ b/regexfactory/patterns.py
@@ -1,71 +1,103 @@
 """Module for Regex pattern classes like `[^abc]` or (abc) a|b"""
 
-from .pattern import RegexPattern
-from typing import Tuple, Union
+from .pattern import RegexPattern, ValidPatternType
+from typing import Union, overload
+import inspect
 
 
 class Group(RegexPattern):
-    def __init__(self, pattern: Union[str, RegexPattern]):
-        super().__init__("(" + str(pattern) + ")")
+    def __init__(self, pattern: ValidPatternType):
+        regex = self.get_regex(pattern)
+        super().__init__(regex)
 
 
 class Or(RegexPattern):
-    def __init__(
-        self,
-        pattern: Union[str, RegexPattern],
-        other_pattern: Union[str, RegexPattern]
-    ):
-        regex = str(pattern) + "|" + str(other_pattern)
+    def __init__(self, pattern: ValidPatternType, other_pattern: ValidPatternType):
+        regex = self.get_regex(pattern) + "|" + self.get_regex(other_pattern)
         super().__init__(Group(regex))
 
 
 class Range(RegexPattern):
-    def __init__(self, a: str, z: str):
-        self.a = a
-        self.z = z
-        regex = f"[{a}-{z}]"
+    def __init__(self, start: str, stop: str):
+        self.start = start
+        self.stop = stop
+        regex = f"[{start}-{stop}]"
         super().__init__(regex)
 
 
 class Set(RegexPattern):
-    def __init__(self, *patterns: Tuple[Union[str, Range]]):
+    def __init__(self, *patterns: Union[str, Range]):
         regex = ''
         for p in patterns:
             if isinstance(p, Range):
-                regex += f"{p.a}-{p.z}"
+                regex += f"{p.start}-{p.stop}"
             else:
                 regex += str(p)
         super().__init__(f"[{regex}]")
 
 
 class NotSet(RegexPattern):
-    def __init__(self, *patterns: Tuple[Union[str, Range]]):
+    def __init__(self, *patterns: Union[str, Range]):
         regex = ''
         for p in patterns:
             if isinstance(p, Range):
-                regex += f"{p.a}-{p.z}"
+                regex += f"{p.start}-{p.stop}"
             else:
                 regex += str(p)
         super().__init__(f"[^{regex}]")
 
 
 class Amount(RegexPattern):
-    def __init__(
-        self,
-        pattern: Union[str, RegexPattern],
-        i: int,
-        j: int = None,
-        ormore: bool = False
-    ):
+    @overload
+    def __init__(self, pattern: ValidPatternType, repetitions: int, or_more: bool = False):
+        ...
+
+    @overload
+    def __init__(self, pattern: ValidPatternType, minimum: int, maximum: int):
+        ...
+
+    def __init__(self, pattern: ValidPatternType, *args, **kwargs):
+        i, j, or_more = self.parse_init_args(*args, **kwargs)
+
         if j is not None:
             amount = f"{i},{j}"
-        elif ormore:
+        elif or_more:
             amount = f"{i},"
         else:
             amount = f"{i}"
-        super().__init__(pattern + "{" + amount + "}")
+
+        regex = self.get_regex(pattern) + "{" + amount + "}"
+        super().__init__(regex)
+
+    @staticmethod
+    def parse_init_args(*args, **kwargs):
+        s1 = inspect.Signature(
+            parameters=(
+                inspect.Parameter("repetitions", kind=inspect.Parameter.POSITIONAL_OR_KEYWORD),
+                inspect.Parameter("or_more", kind=inspect.Parameter.POSITIONAL_OR_KEYWORD)
+            )
+        )
+        s2 = inspect.Signature(
+            parameters=(
+                inspect.Parameter("minimum", kind=inspect.Parameter.POSITIONAL_OR_KEYWORD),
+                inspect.Parameter("maximum", kind=inspect.Parameter.POSITIONAL_OR_KEYWORD)
+            )
+        )
+        try:
+            bound = s1.bind(*args, **kwargs)
+            i = bound.arguments["repetitions"]
+            j = None
+            or_more = bound.arguments["or_more"]
+        except TypeError:
+            bound = s2.bind(*args, **kwargs)
+            i = bound.arguments["minimum"]
+            j = bound.arguments["maximum"]
+            or_more = False
+
+        return i, j, or_more
 
 
 class Optional(RegexPattern):
-    def __init__(self, pattern: Union[str, RegexPattern]):
-        super().__init__(pattern + "?")
+    def __init__(self, pattern: ValidPatternType):
+        regex = self.get_regex(pattern) + "?"
+        super().__init__(regex)

--- a/regexfactory/patterns.py
+++ b/regexfactory/patterns.py
@@ -1,7 +1,8 @@
 """Module for Regex pattern classes like `[^abc]` or (abc) a|b"""
 
 from .pattern import RegexPattern, ValidPatternType
-from typing import Tuple, Optional, overload
+import typing as t
+from typing import overload
 import inspect
 
 
@@ -70,7 +71,7 @@ class Amount(RegexPattern):
         super().__init__(regex)
 
     @staticmethod
-    def parse_init_args(*args, **kwargs) -> Tuple[int, Optional[int], bool]:
+    def parse_init_args(*args, **kwargs) -> t.Tuple[int, t.Optional[int], bool]:
         s1 = inspect.Signature(
             parameters=(
                 inspect.Parameter("repetitions", kind=inspect.Parameter.POSITIONAL_OR_KEYWORD),

--- a/regexfactory/patterns.py
+++ b/regexfactory/patterns.py
@@ -75,7 +75,7 @@ class Amount(RegexPattern):
         s1 = inspect.Signature(
             parameters=(
                 inspect.Parameter("repetitions", kind=inspect.Parameter.POSITIONAL_OR_KEYWORD),
-                inspect.Parameter("or_more", kind=inspect.Parameter.POSITIONAL_OR_KEYWORD)
+                inspect.Parameter("or_more", kind=inspect.Parameter.POSITIONAL_OR_KEYWORD, default=False)
             )
         )
         s2 = inspect.Signature(
@@ -86,11 +86,13 @@ class Amount(RegexPattern):
         )
         try:
             bound = s1.bind(*args, **kwargs)
+            bound.apply_defaults()
             i = bound.arguments["repetitions"]
             j = None
             or_more = bound.arguments["or_more"]
         except TypeError:
             bound = s2.bind(*args, **kwargs)
+            bound.apply_defaults()
             i = bound.arguments["minimum"]
             j = bound.arguments["maximum"]
             or_more = False


### PR DESCRIPTION
Follow [PEP 484](https://www.python.org/dev/peps/pep-0484/) and add type hints to all functions in the code-base. These type-hints are currently compatible with both [`mypy`](https://mypy.readthedocs.io/en/stable/) and [`pyright`](https://github.com/Microsoft/pyright). 

Now that the code-base is compatible with these, you should consider also integrating them into the automated CI/CD github workflows. (If you don't know how to, let me know if you want them added)

Note: I've renamed `ormore` attribute for `Amount` class to a more pythonic `or_more` name and I've also changed the parameter names for `Range` class from `a` and `z` to `start` and `stop`