### PR TITLE
Bugfix/pass flake8 linting

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,12 +28,9 @@ author = "Nate Larsen"
 release = __version__
 branch = (
     "master"
-    if __version__.endswith("a")
-    or __version__.endswith("b")
-    or __version__.endswith("rc")
+    if __version__.endswith("a") or __version__.endswith("b") or __version__.endswith("rc")
     else "v" + __version__
 )
-
 
 # -- General configuration ---------------------------------------------------
 
@@ -52,7 +49,6 @@ templates_path = ["_templates"]
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 autodoc_default_options = {"members": None, "annotation": None}
-
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/examples/urls.py
+++ b/examples/urls.py
@@ -18,8 +18,7 @@ host = Amount(Set(WORD, DIGIT, "."), 1, or_more=True)
 port = Optional(Group(RegexPattern(":") + Amount(DIGIT, 1, or_more=True)))
 path = Amount(
     Group(
-        RegexPattern("/")
-        + Group(Amount(NotSet("/", "#", "?", "&", WHITESPACE), 0, or_more=True))
+        RegexPattern("/") + Group(Amount(NotSet("/", "#", "?", "&", WHITESPACE), 0, or_more=True))
     ),
     0,
     or_more=True,

--- a/regexfactory/__init__.py
+++ b/regexfactory/__init__.py
@@ -12,9 +12,36 @@ The regexfactory module documentation!
 
 """
 
-from .chars import ANY, ANCHOR_START, ANCHOR_END, WHITESPACE, NOTWHITESPACE, WORD, NOTWORD, DIGIT, NOTDIGIT
+from .chars import (
+    ANCHOR_END,
+    ANCHOR_START,
+    ANY,
+    DIGIT,
+    NOTDIGIT,
+    NOTWHITESPACE,
+    NOTWORD,
+    WHITESPACE,
+    WORD,
+)
 from .pattern import RegexPattern, escape, join
-from .patterns import Or, Set, NotSet, Amount, Multi, Optional, Extension, NamedGroup, NamedReference, NumberedReference, Comment, IfAhead, IfNotAhead, IfBehind, IfNotBehind, Group, IfGroup
-
+from .patterns import (
+    Amount,
+    Comment,
+    Extension,
+    Group,
+    IfAhead,
+    IfBehind,
+    IfGroup,
+    IfNotAhead,
+    IfNotBehind,
+    Multi,
+    NamedGroup,
+    NamedReference,
+    NotSet,
+    NumberedReference,
+    Optional,
+    Or,
+    Set,
+)
 
 __version__ = "1.0.0"

--- a/regexfactory/__init__.py
+++ b/regexfactory/__init__.py
@@ -41,6 +41,7 @@ from .patterns import (
     NumberedReference,
     Optional,
     Or,
+    Range,
     Set,
 )
 

--- a/regexfactory/__init__.py
+++ b/regexfactory/__init__.py
@@ -12,8 +12,9 @@ The regexfactory module documentation!
 
 """
 
-from .chars import *
+from .chars import ANY, ANCHOR_START, ANCHOR_END, WHITESPACE, NOTWHITESPACE, WORD, NOTWORD, DIGIT, NOTDIGIT
 from .pattern import RegexPattern, escape, join
-from .patterns import *
+from .patterns import Or, Set, NotSet, Amount, Multi, Optional, Extension, NamedGroup, NamedReference, NumberedReference, Comment, IfAhead, IfNotAhead, IfBehind, IfNotBehind, Group, IfGroup
+
 
 __version__ = "1.0.0"


### PR DESCRIPTION
# Summary

This PR solves CI errors seen in [the most recent `master` commit as of June 25 2023](https://github.com/GrandMoff100/RegexFactory/actions/runs/5033050983/jobs/9027040421) . The changes in this PR spawned from work on issue #11 (PR incoming) when updating workflows to run linting and tests. 

# Changes Made

1. Address `flake8` errors in:
  - `docs/conf.py`
  - `examples/urls.py`
  - `regexfactory/__init__.py`

To validate these changes execute run the following commands:

```sh
pip install flake8 black pylint isort
flake8 ## to check flake8 globally
black regexfactory --check
isort regexfactory --check
pylint regexfactory
```

# Considerations

+ This PR must be merged before the upcoming `pytest` pull request. 

# Other

I am excited to contribute to this package! Regular expressions can be a pain in the behind and this package simplifies the regex experience. 