### PR TITLE
Feature/issue 11 start pytest testing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,6 +31,6 @@ jobs:
         run: pytest
 
   code_style_checking:
-    uses: GrandMoff100/RegexFactory/.github/workflows/styling.yml@master
+    uses: ./.github/workflows/styling.yml
     secrets:
       envPAT: ${{ secrets.envPAT }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,5 +32,3 @@ jobs:
 
   code_style_checking:
     uses: ./.github/workflows/styling.yml
-    secrets:
-      envPAT: ${{ secrets.envPAT }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,36 @@
+name: CI Testing
+
+on:
+  push:
+    pull_request:
+
+    workflow_dispatch:
+
+jobs:
+  testing:
+    strategy:
+      matrix:
+        python:
+          - "3.8"
+          - "3.9"
+          - "3.10"
+          - "3.11"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: Install deps
+        run: |
+          pip3 --version
+          pip3 install .[dev]
+
+      - name: Run tests
+        run: pytest
+
+  code_style_checking:
+    uses: GrandMoff100/RegexFactory/.github/workflows/styling.yml
+    secrets:
+      envPAT: ${{ secrets.envPAT }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,6 +31,6 @@ jobs:
         run: pytest
 
   code_style_checking:
-    uses: GrandMoff100/RegexFactory/.github/workflows/styling.yml
+    uses: GrandMoff100/RegexFactory/.github/workflows/styling.yml@main
     secrets:
       envPAT: ${{ secrets.envPAT }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,6 +31,6 @@ jobs:
         run: pytest
 
   code_style_checking:
-    uses: GrandMoff100/RegexFactory/.github/workflows/styling.yml@main
+    uses: GrandMoff100/RegexFactory/.github/workflows/styling.yml@master
     secrets:
       envPAT: ${{ secrets.envPAT }}

--- a/.github/workflows/styling.yml
+++ b/.github/workflows/styling.yml
@@ -10,6 +10,7 @@ on:
     paths:
       - "**.py"
   workflow_dispatch:
+  workflow_call:
 
 jobs:
   code_style_checking:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,12 +28,9 @@ author = "Nate Larsen"
 release = __version__
 branch = (
     "master"
-    if __version__.endswith("a")
-    or __version__.endswith("b")
-    or __version__.endswith("rc")
+    if __version__.endswith("a") or __version__.endswith("b") or __version__.endswith("rc")
     else "v" + __version__
 )
-
 
 # -- General configuration ---------------------------------------------------
 
@@ -52,7 +49,6 @@ templates_path = ["_templates"]
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 autodoc_default_options = {"members": None, "annotation": None}
-
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/examples/urls.py
+++ b/examples/urls.py
@@ -18,8 +18,7 @@ host = Amount(Set(WORD, DIGIT, "."), 1, or_more=True)
 port = Optional(Group(RegexPattern(":") + Amount(DIGIT, 1, or_more=True)))
 path = Amount(
     Group(
-        RegexPattern("/")
-        + Group(Amount(NotSet("/", "#", "?", "&", WHITESPACE), 0, or_more=True))
+        RegexPattern("/") + Group(Amount(NotSet("/", "#", "?", "&", WHITESPACE), 0, or_more=True))
     ),
     0,
     or_more=True,

--- a/regexfactory/__init__.py
+++ b/regexfactory/__init__.py
@@ -12,8 +12,9 @@ The regexfactory module documentation!
 
 """
 
-from .chars import *
+from .chars import ANY, ANCHOR_START, ANCHOR_END, WHITESPACE, NOTWHITESPACE, WORD, NOTWORD, DIGIT, NOTDIGIT
 from .pattern import RegexPattern, escape, join
-from .patterns import *
+from .patterns import Or, Set, NotSet, Amount, Multi, Optional, Extension, NamedGroup, NamedReference, NumberedReference, Comment, IfAhead, IfNotAhead, IfBehind, IfNotBehind, Group, IfGroup
+
 
 __version__ = "1.0.0"

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,9 @@ test =
 [tool:pytest]
 markers =
     patterns: Tests for classes in regexfactory/patterns.py
+addopts = -ra --hypothesis-show-statistics --hypothesis-profile=default
+testpaths =
+    tests
 
 [flake8]
 ignore = E501

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,6 @@ test =
     hypothesis
 
 [tool:pytest]
-addopts = --hypothesis-show-statistics
 markers =
     patterns: Tests for classes in regexfactory/patterns.py
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,11 @@ zip_safe = True
 packages = regexfactory
 
 [options.extras_require]
-test =
+dev =
+    isort
+    black
+    flake8
+    pylint
     pytest
     hypothesis
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,7 @@ test =
 [tool:pytest]
 markers =
     patterns: Tests for classes in regexfactory/patterns.py
+    pattern: Tests for classes in regexfactory/pattern.py
 addopts = -ra --hypothesis-show-statistics --hypothesis-profile=default
 testpaths =
     tests

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,16 @@ classifiers =
 zip_safe = True
 packages = regexfactory
 
+[options.extras_require]
+test =
+    pytest
+    hypothesis
+
+[tool:pytest]
+addopts = --hypothesis-show-statistics
+markers =
+    patterns: Tests for classes in regexfactory/patterns.py
+
 [flake8]
 ignore = E501
 exclude = .git, __pycache__, .github

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,4 @@
+from hypothesis import settings
+
+settings.register_profile('default',
+                          max_examples=500)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
 from hypothesis import settings
 
 # Set default profile to use 500 examples
-settings.register_profile('default', max_examples=500)
+settings.register_profile("default", max_examples=500)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
 from hypothesis import settings
 
-settings.register_profile('default',
-                          max_examples=500)
+# Set default profile to use 500 examples
+settings.register_profile('default', max_examples=500)

--- a/tests/strategies.py
+++ b/tests/strategies.py
@@ -3,23 +3,15 @@ from hypothesis import strategies as st
 from regexfactory.pattern import ESCAPED_CHARACTERS
 
 # Strategy to generate characters that are not used in escapes
-non_escape_char = st.characters(
-    blacklist_characters=list(ESCAPED_CHARACTERS)
-)
+non_escape_char = st.characters(blacklist_characters=list(ESCAPED_CHARACTERS))
 
 
 # Strategy to generate text that avoids escaped characters
-non_escaped_text = st.text(
-    min_size=1,
-    alphabet=non_escape_char
-)
+non_escaped_text = st.text(min_size=1, alphabet=non_escape_char)
 
 
 # Strategy to produce either None or a positive integer
-optional_step = st.one_of(
-    st.none(),
-    st.integers(min_value=1)
-)
+optional_step = st.one_of(st.none(), st.integers(min_value=1))
 
 
 def build_bounds(lower_bound, step) -> range:
@@ -28,4 +20,3 @@ def build_bounds(lower_bound, step) -> range:
     """
     upper_bound = lower_bound + step
     return range(lower_bound, upper_bound + 1)
-

--- a/tests/strategies.py
+++ b/tests/strategies.py
@@ -1,9 +1,6 @@
-from typing import Optional
-
 from hypothesis import strategies as st
 
-from regexfactory import Amount
-from regexfactory.pattern import ESCAPED_CHARACTERS, ValidPatternType
+from regexfactory.pattern import ESCAPED_CHARACTERS
 
 # Strategy to generate text that avoids escaped characters
 non_escaped_text = st.text(
@@ -12,6 +9,7 @@ non_escaped_text = st.text(
         blacklist_characters=list(ESCAPED_CHARACTERS)
     )
 )
+
 
 # Strategy to produce either None or a positive integer
 optional_step = st.one_of(
@@ -26,3 +24,4 @@ def build_bounds(lower_bound, step) -> range:
     """
     upper_bound = lower_bound + step
     return range(lower_bound, upper_bound + 1)
+

--- a/tests/strategies.py
+++ b/tests/strategies.py
@@ -1,6 +1,8 @@
 from regexfactory import Amount
-from regexfactory.pattern import ESCAPED_CHARACTERS
+from regexfactory.pattern import ESCAPED_CHARACTERS, ValidPatternType
 from string import printable
+from typing import Optional
+
 
 ## Variable that defines all characters that are not used in escapes.
 non_escape_printable = "".join(
@@ -14,6 +16,26 @@ def build_bounds(lower_bound, step) -> range:
     """
     upper_bound = lower_bound + step
     return range(lower_bound, upper_bound + 1)
+
+
+def build_amount(pattern: ValidPatternType, start: int, or_more: bool, greedy: bool, step: Optional[int]):
+    """
+    General Amount builder. This function will be repurposed with hard-coded
+    values for a parameter when used with more specific use cases.
+    Note that the `j` parameter is constructed as the step plus start
+    """
+    stop_value = None
+    if step is not None:
+        stop_value = start + step
+    return Amount(
+        pattern=pattern,
+        i=start,
+        j=stop_value,
+        or_more=or_more,
+        greedy=greedy
+    )
+
+
 
 
 def build_amount_greedy(words, count, greedy):

--- a/tests/strategies.py
+++ b/tests/strategies.py
@@ -1,0 +1,19 @@
+from regexfactory import Amount
+
+def build_bounds(lower_bound, step) -> range:
+    """
+    Function to generate a tuple of (lower, upper) in which lower < upper
+    """
+    upper_bound = lower_bound + step
+    return range(lower_bound, upper_bound + 1)
+
+def build_amount_greedy(words, count, greedy):
+    return (
+        Amount(
+            words,
+            count,
+            or_more=False,
+            greedy=greedy
+        ),
+        greedy
+    )

--- a/tests/strategies.py
+++ b/tests/strategies.py
@@ -26,22 +26,3 @@ def build_bounds(lower_bound, step) -> range:
     """
     upper_bound = lower_bound + step
     return range(lower_bound, upper_bound + 1)
-
-
-def build_amount(pattern: ValidPatternType, start: int, or_more: bool, greedy: bool, step: Optional[int]):
-    """
-    General Amount builder. Note that the `j` parameter is constructed as
-        the step plus start when step is defined. When step is None we assume
-        that no upper bound is present.
-    """
-    stop_value = None
-    if step is not None:
-        stop_value = start + step
-    return Amount(
-        pattern=pattern,
-        i=start,
-        j=stop_value,
-        or_more=or_more,
-        greedy=greedy
-    )
-

--- a/tests/strategies.py
+++ b/tests/strategies.py
@@ -1,4 +1,12 @@
 from regexfactory import Amount
+from regexfactory.pattern import ESCAPED_CHARACTERS
+from string import printable
+
+## Variable that defines all characters that are not used in escapes.
+non_escape_printable = "".join(
+    list(filter(lambda z: z not in list(ESCAPED_CHARACTERS), list(printable)))
+)
+
 
 def build_bounds(lower_bound, step) -> range:
     """
@@ -7,7 +15,11 @@ def build_bounds(lower_bound, step) -> range:
     upper_bound = lower_bound + step
     return range(lower_bound, upper_bound + 1)
 
+
 def build_amount_greedy(words, count, greedy):
+    """
+    Function to build a greedy instance of `Amount` .
+    """
     return (
         Amount(
             words,

--- a/tests/strategies.py
+++ b/tests/strategies.py
@@ -1,12 +1,22 @@
-from regexfactory import Amount
-from regexfactory.pattern import ESCAPED_CHARACTERS, ValidPatternType
-from string import printable
 from typing import Optional
 
+from hypothesis import strategies as st
 
-## Variable that defines all characters that are not used in escapes.
-non_escape_printable = "".join(
-    list(filter(lambda z: z not in list(ESCAPED_CHARACTERS), list(printable)))
+from regexfactory import Amount
+from regexfactory.pattern import ESCAPED_CHARACTERS, ValidPatternType
+
+# Strategy to generate text that avoids escaped characters
+non_escaped_text = st.text(
+    min_size=1,
+    alphabet=st.characters(
+        blacklist_characters=list(ESCAPED_CHARACTERS)
+    )
+)
+
+# Strategy to produce either None or a positive integer
+optional_step = st.one_of(
+    st.none(),
+    st.integers(min_value=1)
 )
 
 
@@ -20,9 +30,9 @@ def build_bounds(lower_bound, step) -> range:
 
 def build_amount(pattern: ValidPatternType, start: int, or_more: bool, greedy: bool, step: Optional[int]):
     """
-    General Amount builder. This function will be repurposed with hard-coded
-    values for a parameter when used with more specific use cases.
-    Note that the `j` parameter is constructed as the step plus start
+    General Amount builder. Note that the `j` parameter is constructed as
+        the step plus start when step is defined. When step is None we assume
+        that no upper bound is present.
     """
     stop_value = None
     if step is not None:
@@ -35,19 +45,3 @@ def build_amount(pattern: ValidPatternType, start: int, or_more: bool, greedy: b
         greedy=greedy
     )
 
-
-
-
-def build_amount_greedy(words, count, greedy):
-    """
-    Function to build a greedy instance of `Amount` .
-    """
-    return (
-        Amount(
-            words,
-            count,
-            or_more=False,
-            greedy=greedy
-        ),
-        greedy
-    )

--- a/tests/strategies.py
+++ b/tests/strategies.py
@@ -2,12 +2,16 @@ from hypothesis import strategies as st
 
 from regexfactory.pattern import ESCAPED_CHARACTERS
 
+# Strategy to generate characters that are not used in escapes
+non_escape_char = st.characters(
+    blacklist_characters=list(ESCAPED_CHARACTERS)
+)
+
+
 # Strategy to generate text that avoids escaped characters
 non_escaped_text = st.text(
     min_size=1,
-    alphabet=st.characters(
-        blacklist_characters=list(ESCAPED_CHARACTERS)
-    )
+    alphabet=non_escape_char
 )
 
 

--- a/tests/test_amount.py
+++ b/tests/test_amount.py
@@ -1,10 +1,7 @@
 from regexfactory import Amount
 import pytest
-from hypothesis import (
-    given,
-    strategies as st
-)
-from .strategies import *
+from hypothesis import given, strategies as st
+from tests.strategies import build_amount_greedy, build_bounds
 
 
 @pytest.mark.patterns
@@ -43,3 +40,15 @@ def test_amount_non_greedy(word, count):
     actual = Amount(word, count, greedy=False)
     assert actual.regex.endswith("?")
 
+
+@given(st.builds(
+    build_amount_greedy,
+    words=st.text(min_size=1),
+    count=st.integers(min_value=1),
+    greedy=st.booleans()
+))
+def test_amount_greedy(amtTuple: tuple[Amount, bool]):
+    amt = amtTuple[0]
+    greedy = amtTuple[1]
+    ## if greedy = false then regex ends with ?
+    assert greedy != amt.regex.endswith("?")

--- a/tests/test_amount.py
+++ b/tests/test_amount.py
@@ -1,14 +1,15 @@
 from regexfactory import Amount
 import pytest
-from hypothesis import given, strategies as st
-from tests.strategies import build_amount_greedy, build_bounds
+from hypothesis import given, settings, strategies as st
+from tests.strategies import build_amount_greedy, build_bounds, build_amount
 
 
 @pytest.mark.patterns
 @given(st.text(min_size=1), st.integers(min_value=1))
-def test_amount(word, count):
+def test_amount_single_count(word, count):
     actual = Amount(word, i=count)
     assert actual.regex == "{word}{{{count}}}".format(word=word, count=str(count))
+
 
 
 @pytest.mark.patterns
@@ -22,7 +23,6 @@ def test_amount(word, count):
 )
 def test_amount_lower_upper(word, bound: range):
     actual = Amount(word, bound.start, bound.stop)
-    str(actual)
     expected = "{word}{{{lower},{upper}}}".format(word=word, lower=str(bound.start), upper=str(bound.stop))
     assert actual.regex == expected
 
@@ -35,10 +35,19 @@ def test_amount_or_more(word, count):
 
 
 @pytest.mark.patterns
-@given(st.text(min_size=1), st.integers(min_value=1))
-def test_amount_non_greedy(word, count):
-    actual = Amount(word, count, greedy=False)
-    assert actual.regex.endswith("?")
+@given(st.builds(
+    lambda pattern, start, or_more, step: build_amount(pattern=pattern, start=start, or_more=or_more, greedy=False, step=step),
+    st.text(min_size=1),
+    st.integers(min_value=1, max_value=5),
+    st.integers(min_value=1),
+    st.booleans()
+))
+@settings(max_examples=500)
+def test_amount_non_greedy(amt):
+    """
+    Test to ensure that instances of Amount with greedy as False will end with "?"
+    """
+    assert amt.regex.endswith("?")
 
 
 @given(st.builds(

--- a/tests/test_amount.py
+++ b/tests/test_amount.py
@@ -4,12 +4,42 @@ from hypothesis import (
     given,
     strategies as st
 )
+from .strategies import *
 
 
 @pytest.mark.patterns
 @given(st.text(min_size=1), st.integers(min_value=1))
 def test_amount(word, count):
-    actual = Amount(word, count)
+    actual = Amount(word, i=count)
     assert actual.regex == "{word}{{{count}}}".format(word=word, count=str(count))
 
+
+@pytest.mark.patterns
+@given(
+    st.text(min_size=1),
+    st.builds(
+        build_bounds,
+        lower_bound=st.integers(min_value=1),
+        step=st.integers(min_value=1)
+    )
+)
+def test_amount_lower_upper(word, bound: range):
+    actual = Amount(word, bound.start, bound.stop)
+    str(actual)
+    expected = "{word}{{{lower},{upper}}}".format(word=word, lower=str(bound.start), upper=str(bound.stop))
+    assert actual.regex == expected
+
+
+@pytest.mark.patterns
+@given(st.text(min_size=1), st.integers(min_value=1))
+def test_amount_or_more(word, count):
+    actual = Amount(word, count, or_more=True)
+    assert actual.regex == "{word}{{{count},}}".format(word=word, count=str(count))
+
+
+@pytest.mark.patterns
+@given(st.text(min_size=1), st.integers(min_value=1))
+def test_amount_non_greedy(word, count):
+    actual = Amount(word, count, greedy=False)
+    assert actual.regex.endswith("?")
 

--- a/tests/test_amount.py
+++ b/tests/test_amount.py
@@ -1,8 +1,11 @@
+from typing import Optional
+
 import pytest
-from hypothesis import given, strategies as st
+from hypothesis import given
+from hypothesis import strategies as st
+from strategies import build_bounds, optional_step
 
 from regexfactory import Amount, ValidPatternType
-from strategies import build_bounds, optional_step
 
 
 def build_amount(pattern: ValidPatternType, start: int, or_more: bool, greedy: bool, step: Optional[int]):

--- a/tests/test_amount.py
+++ b/tests/test_amount.py
@@ -1,0 +1,15 @@
+from regexfactory import Amount
+import pytest
+from hypothesis import (
+    given,
+    strategies as st
+)
+
+
+@pytest.mark.patterns
+@given(st.text(min_size=1), st.integers(min_value=1))
+def test_amount(word, count):
+    actual = Amount(word, count)
+    assert actual.regex == "{word}{{{count}}}".format(word=word, count=str(count))
+
+

--- a/tests/test_amount.py
+++ b/tests/test_amount.py
@@ -8,7 +8,13 @@ from strategies import build_bounds, optional_step
 from regexfactory import Amount, ValidPatternType
 
 
-def build_amount(pattern: ValidPatternType, start: int, or_more: bool, greedy: bool, step: Optional[int]):
+def build_amount(
+    pattern: ValidPatternType,
+    start: int,
+    or_more: bool,
+    greedy: bool,
+    step: Optional[int],
+):
     """
     General Amount builder. Note that the `j` parameter is constructed as
         the step plus start when step is defined. When step is None we assume
@@ -18,11 +24,7 @@ def build_amount(pattern: ValidPatternType, start: int, or_more: bool, greedy: b
     if step is not None:
         stop_value = start + step
     return Amount(
-        pattern=pattern,
-        i=start,
-        j=stop_value,
-        or_more=or_more,
-        greedy=greedy
+        pattern=pattern, i=start, j=stop_value, or_more=or_more, greedy=greedy
     )
 
 
@@ -43,8 +45,8 @@ def test_amount_single_count(word, count):
     st.builds(
         build_bounds,
         lower_bound=st.integers(min_value=1),
-        step=st.integers(min_value=1)
-    )
+        step=st.integers(min_value=1),
+    ),
 )
 def test_amount_lower_upper(word, bound: range):
     """
@@ -52,7 +54,9 @@ def test_amount_lower_upper(word, bound: range):
         regex of the resulting `Amount` will be of the form {word}{lower,upper}.
     """
     actual = Amount(word, bound.start, bound.stop)
-    expected = "{word}{{{lower},{upper}}}".format(word=word, lower=str(bound.start), upper=str(bound.stop))
+    expected = "{word}{{{lower},{upper}}}".format(
+        word=word, lower=str(bound.start), upper=str(bound.stop)
+    )
     assert actual.regex == expected
 
 
@@ -68,14 +72,16 @@ def test_amount_or_more(word, count):
 
 
 @pytest.mark.patterns
-@given(st.builds(
-    build_amount,
-    pattern=st.text(min_size=1),
-    start=st.integers(min_value=1),
-    or_more=st.booleans(),
-    greedy=st.just(False),
-    step=optional_step
-))
+@given(
+    st.builds(
+        build_amount,
+        pattern=st.text(min_size=1),
+        start=st.integers(min_value=1),
+        or_more=st.booleans(),
+        greedy=st.just(False),
+        step=optional_step,
+    )
+)
 def test_amount_non_greedy(amt):
     """
     Test to ensure that instances of Amount with greedy as False will end with "?"

--- a/tests/test_amount.py
+++ b/tests/test_amount.py
@@ -1,15 +1,37 @@
-from regexfactory import Amount
 import pytest
-from hypothesis import given, settings, strategies as st
-from tests.strategies import build_amount_greedy, build_bounds, build_amount
+from hypothesis import given, strategies as st
+
+from regexfactory import Amount, ValidPatternType
+from strategies import build_bounds, optional_step
+
+
+def build_amount(pattern: ValidPatternType, start: int, or_more: bool, greedy: bool, step: Optional[int]):
+    """
+    General Amount builder. Note that the `j` parameter is constructed as
+        the step plus start when step is defined. When step is None we assume
+        that no upper bound is present.
+    """
+    stop_value = None
+    if step is not None:
+        stop_value = start + step
+    return Amount(
+        pattern=pattern,
+        i=start,
+        j=stop_value,
+        or_more=or_more,
+        greedy=greedy
+    )
 
 
 @pytest.mark.patterns
 @given(st.text(min_size=1), st.integers(min_value=1))
 def test_amount_single_count(word, count):
-    actual = Amount(word, i=count)
+    """
+    Test to ensure that when `or_more=False` and no upper bound is
+        provided the regex will be of the form word{count}.
+    """
+    actual = Amount(word, i=count, or_more=False)
     assert actual.regex == "{word}{{{count}}}".format(word=word, count=str(count))
-
 
 
 @pytest.mark.patterns
@@ -22,6 +44,10 @@ def test_amount_single_count(word, count):
     )
 )
 def test_amount_lower_upper(word, bound: range):
+    """
+    Test to ensure that if a lower and upper bound are provided then the
+        regex of the resulting `Amount` will be of the form {word}{lower,upper}.
+    """
     actual = Amount(word, bound.start, bound.stop)
     expected = "{word}{{{lower},{upper}}}".format(word=word, lower=str(bound.start), upper=str(bound.stop))
     assert actual.regex == expected
@@ -30,34 +56,25 @@ def test_amount_lower_upper(word, bound: range):
 @pytest.mark.patterns
 @given(st.text(min_size=1), st.integers(min_value=1))
 def test_amount_or_more(word, count):
+    """
+    Test to ensure that when `or_more=True` and no upper bound is
+        provided the regex will be of the form word{count,}.
+    """
     actual = Amount(word, count, or_more=True)
     assert actual.regex == "{word}{{{count},}}".format(word=word, count=str(count))
 
 
 @pytest.mark.patterns
 @given(st.builds(
-    lambda pattern, start, or_more, step: build_amount(pattern=pattern, start=start, or_more=or_more, greedy=False, step=step),
-    st.text(min_size=1),
-    st.integers(min_value=1, max_value=5),
-    st.integers(min_value=1),
-    st.booleans()
+    build_amount,
+    pattern=st.text(min_size=1),
+    start=st.integers(min_value=1),
+    or_more=st.booleans(),
+    greedy=st.just(False),
+    step=optional_step
 ))
-@settings(max_examples=500)
 def test_amount_non_greedy(amt):
     """
     Test to ensure that instances of Amount with greedy as False will end with "?"
     """
     assert amt.regex.endswith("?")
-
-
-@given(st.builds(
-    build_amount_greedy,
-    words=st.text(min_size=1),
-    count=st.integers(min_value=1),
-    greedy=st.booleans()
-))
-def test_amount_greedy(amtTuple: tuple[Amount, bool]):
-    amt = amtTuple[0]
-    greedy = amtTuple[1]
-    ## if greedy = false then regex ends with ?
-    assert greedy != amt.regex.endswith("?")

--- a/tests/test_join.py
+++ b/tests/test_join.py
@@ -7,14 +7,7 @@ from regexfactory.pattern import join
 
 
 @pytest.mark.pattern
-@given(
-    st.lists(
-        elements=non_escaped_text,
-        min_size=1,
-        max_size=10,
-        unique=True
-    )
-)
+@given(st.lists(elements=non_escaped_text, min_size=1, max_size=10, unique=True))
 @example(words=["0", "1"])
 def test_join(words: list):
     """

--- a/tests/test_join.py
+++ b/tests/test_join.py
@@ -1,18 +1,15 @@
 import pytest
-from hypothesis import given, example, strategies as st
+from hypothesis import example, given
+from hypothesis import strategies as st
+from strategies import non_escaped_text
 
-from regexfactory.pattern import join, ESCAPED_CHARACTERS
+from regexfactory.pattern import join
 
 
 @pytest.mark.pattern
 @given(
     st.lists(
-        elements=st.text(
-            min_size=1,
-            alphabet=st.characters(
-                blacklist_characters=list(ESCAPED_CHARACTERS)
-            )
-        ),
+        elements=non_escaped_text,
         min_size=1,
         max_size=10,
         unique=True
@@ -22,7 +19,7 @@ from regexfactory.pattern import join, ESCAPED_CHARACTERS
 def test_join(words: list):
     """
     Tests to capture that the join function concatenates the expressions and
-    each word in the list is found in the larger regex.
+        each word in the list is found in the larger regex.
     """
     joined_regex = join(*words)
     assert joined_regex.regex == "".join(words)

--- a/tests/test_join.py
+++ b/tests/test_join.py
@@ -1,0 +1,28 @@
+import pytest
+from hypothesis import given, example, strategies as st
+
+from regexfactory.pattern import join, ESCAPED_CHARACTERS
+
+
+@pytest.mark.pattern
+@given(
+    st.lists(
+        elements=st.text(
+            min_size=1,
+            alphabet=st.characters(
+                blacklist_characters=list(ESCAPED_CHARACTERS)
+            )
+        ),
+        min_size=1,
+        max_size=10,
+        unique=True
+    )
+)
+@example(words=["0", "1"])
+def test_join(words: list):
+    """
+    Tests to capture that the join function concatenates the expressions and
+    each word in the list is found in the larger regex.
+    """
+    joined_regex = join(*words)
+    assert joined_regex.regex == "".join(words)

--- a/tests/test_or.py
+++ b/tests/test_or.py
@@ -20,13 +20,7 @@ from regexfactory import Or
 def test_matching_or(arr: list):
     actual = Or(*arr)
     if len(arr) == 1:
-        assert (
-            isinstance(actual.match(arr[0]), re.Match)
-        )
+        assert isinstance(actual.match(arr[0]), re.Match)
     else:
         for value in arr:
-            assert (
-                isinstance(actual.match(value), re.Match)
-            )
-
-
+            assert isinstance(actual.match(value), re.Match)

--- a/tests/test_or.py
+++ b/tests/test_or.py
@@ -1,0 +1,29 @@
+from regexfactory import Or
+import pytest
+from hypothesis import (
+    example,
+    given,
+    strategies as st
+)
+import re
+from strategies import non_escape_printable
+
+
+@pytest.mark.patterns
+@given(
+    st.lists(
+        st.text(alphabet=non_escape_printable, min_size=1),
+        min_size=2,
+        max_size=10,
+        unique=True
+    )
+)
+@example(arr=["0", "0"])
+def test_matching_or(arr: list):
+    actual = Or(*arr)
+    for value in arr:
+        assert (
+            isinstance(actual.match(value), re.Match)
+        )
+
+

--- a/tests/test_or.py
+++ b/tests/test_or.py
@@ -1,29 +1,32 @@
-from regexfactory import Or
-import pytest
-from hypothesis import (
-    example,
-    given,
-    strategies as st
-)
 import re
-from strategies import non_escape_printable
+
+import pytest
+from hypothesis import example, given
+from hypothesis import strategies as st
+from strategies import non_escaped_text
+
+from regexfactory import Or
 
 
 @pytest.mark.patterns
 @given(
     st.lists(
-        st.text(alphabet=non_escape_printable, min_size=1),
-        min_size=2,
+        non_escaped_text,
+        min_size=1,
         max_size=10,
-        unique=True
     )
 )
 @example(arr=["0", "0"])
 def test_matching_or(arr: list):
     actual = Or(*arr)
-    for value in arr:
+    if len(arr) == 1:
         assert (
-            isinstance(actual.match(value), re.Match)
+            isinstance(actual.match(arr[0]), re.Match)
         )
+    else:
+        for value in arr:
+            assert (
+                isinstance(actual.match(value), re.Match)
+            )
 
 

--- a/tests/test_range.py
+++ b/tests/test_range.py
@@ -13,13 +13,13 @@ def test_numeric_range_simple():
 @pytest.mark.patterns
 @pytest.mark.parametrize(
     "start, stop, expected",
-    [("0", "9", "[0-9]"),
-     ("a", "f", "[a-f]"),
-     ("r", "q", "[r-q]"),
-     ("A", "Z", "[A-Z]")]
+    [
+        ("0", "9", "[0-9]"),
+        ("a", "f", "[a-f]"),
+        ("r", "q", "[r-q]"),
+        ("A", "Z", "[A-Z]"),
+    ],
 )
 def test_numeric_range_parameters(start, stop, expected):
     actual = Range(start=start, stop=stop)
     assert actual.regex == expected
-
-

--- a/tests/test_range.py
+++ b/tests/test_range.py
@@ -1,9 +1,6 @@
-from regexfactory import Range
 import pytest
 
-
-def convert_to_ord(character: str) -> int:
-    ord(character.encode("utf-8"))
+from regexfactory import Range
 
 
 @pytest.mark.patterns

--- a/tests/test_range.py
+++ b/tests/test_range.py
@@ -1,0 +1,28 @@
+from regexfactory import Range
+import pytest
+
+
+def convert_to_ord(character: str) -> int:
+    ord(character.encode("utf-8"))
+
+
+@pytest.mark.patterns
+def test_numeric_range_simple():
+    start = "0"
+    end = "9"
+    assert Range(start, end).regex == "[0-9]"
+
+
+@pytest.mark.patterns
+@pytest.mark.parametrize(
+    "start, stop, expected",
+    [("0", "9", "[0-9]"),
+     ("a", "f", "[a-f]"),
+     ("r", "q", "[r-q]"),
+     ("A", "Z", "[A-Z]")]
+)
+def test_numeric_range_parameters(start, stop, expected):
+    actual = Range(start=start, stop=stop)
+    assert actual.regex == expected
+
+

--- a/tests/test_range.py
+++ b/tests/test_range.py
@@ -4,7 +4,7 @@ from regexfactory import Range
 
 
 @pytest.mark.patterns
-def test_numeric_range_simple():
+def test_numeric_range():
     start = "0"
     end = "9"
     assert Range(start, end).regex == "[0-9]"
@@ -20,6 +20,6 @@ def test_numeric_range_simple():
         ("A", "Z", "[A-Z]"),
     ],
 )
-def test_numeric_range_parameters(start, stop, expected):
+def test_range_parameters(start, stop, expected):
     actual = Range(start=start, stop=stop)
     assert actual.regex == expected

--- a/tests/test_set.py
+++ b/tests/test_set.py
@@ -21,4 +21,3 @@ def test_set(chars: list):
         assert (
             isinstance(actual.match(value), re.Match)
         )
-

--- a/tests/test_set.py
+++ b/tests/test_set.py
@@ -9,15 +9,8 @@ from regexfactory import Set
 
 
 @pytest.mark.patterns
-@given(
-    st.lists(
-        elements=non_escape_char,
-        min_size=1
-    )
-)
+@given(st.lists(elements=non_escape_char, min_size=1))
 def test_set(chars: list):
     actual = Set(*chars)
     for value in chars:
-        assert (
-            isinstance(actual.match(value), re.Match)
-        )
+        assert isinstance(actual.match(value), re.Match)

--- a/tests/test_set.py
+++ b/tests/test_set.py
@@ -1,0 +1,22 @@
+import re
+
+import pytest
+from hypothesis import given, strategies as st
+
+from regexfactory import Set
+from regexfactory.pattern import ESCAPED_CHARACTERS
+
+
+@pytest.mark.patterns
+@given(
+    st.lists(
+        elements=st.characters(blacklist_characters=list(ESCAPED_CHARACTERS)),
+    )
+)
+def test_set(chars: list):
+    actual = Set(*chars)
+    for value in chars:
+        assert (
+            isinstance(actual.match(value), re.Match)
+        )
+

--- a/tests/test_set.py
+++ b/tests/test_set.py
@@ -1,16 +1,18 @@
 import re
 
 import pytest
-from hypothesis import given, strategies as st
+from hypothesis import given
+from hypothesis import strategies as st
+from strategies import non_escape_char
 
 from regexfactory import Set
-from regexfactory.pattern import ESCAPED_CHARACTERS
 
 
 @pytest.mark.patterns
 @given(
     st.lists(
-        elements=st.characters(blacklist_characters=list(ESCAPED_CHARACTERS)),
+        elements=non_escape_char,
+        min_size=1
     )
 )
 def test_set(chars: list):


### PR DESCRIPTION
# Summary

This PR provides a starting point to fully address issue #11 . More specifically some of the operations in `patterns.py` are tested using [property-based testing](https://increment.com/testing/in-praise-of-property-based-testing/). This PR is intended to be a first step in fully testing this package and provide velocity by accounting for house-keeping items (such as the `dev` installation type).

# Issues Addressed

+ #11 

# Changes made

1. Create a `dev` installation type in `setup.cfg` so that development dependencies can be installed as follows:

```sh
pip install -e .[dev]
```

2. Construct `dev` package list from an examination of workflows and libraries needed for testing, namely `pytest` and `hypothesis`
3. Add `pytest` configuration within `setup.cfg`
4. Add `default` hypothesis profile in `tests/conftest.py`
5. Create place for common strategy functions in `tests/strategies.py`
6. Add unit tests for the following functionality:
  - `Set`
  - `Or`
  - `Amount` (Limited and not property-based at this time)
  - `join`
  - `Range`
7. Add a `main` workflow to run unit tests either on command or within a PR
8. Update `styling` workflow to allow calling by workflow dispatch
9. Include changes from #14 so that all checks pass

# Considerations

+ The builders for all `patterns` tests generate a string. In a future release we can broaden the scope of these tests to generate a `ValidPatternType`
+ The `main.yml` workflow refers to the version of `styling.yml` within the repository at the time of commit. In the future this will be updated to reflect the `master` state after `styling.yml` is merged into `master`

# Other

While the process of unit testing everything in the package will be a long process I hope this PR provides velocity to kick off the process! 
